### PR TITLE
feat(utils): Implement withAsPolymorphic HOC

### DIFF
--- a/packages/with-as-polymorphic/CHANGELOG.md
+++ b/packages/with-as-polymorphic/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]

--- a/packages/with-as-polymorphic/README.md
+++ b/packages/with-as-polymorphic/README.md
@@ -1,0 +1,33 @@
+# @bliss/with-as-polymorphic
+
+**This utility is intended for internal use only and should not be used publicly.**
+
+## Installation
+
+To install this package, you can use npm, yarn or pnpm:
+
+npm:
+
+```sh
+npm install @bliss/with-as-polymorphic
+```
+
+yarn:
+
+```sh
+yarn add @bliss/with-as-polymorphic
+```
+
+pnpm:
+
+```sh
+pnpm install @bliss/with-as-polymorphic
+```
+
+## Contribution
+
+For information on contributing to the project, please see the [contributing guidelines](https://github.com/bliss-design/bliss/blob/main/CONTRIBUTING.md).
+
+## License
+
+This project is licensed under the MIT License. Please refer to the [LICENSE](https://github.com/bliss-design/bliss/blob/main/LICENSE) file for more information.

--- a/packages/with-as-polymorphic/package.json
+++ b/packages/with-as-polymorphic/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@bliss/with-as-polymorphic",
+  "version": "1.0.0",
+  "description": "This utility is intended for internal use only and should not be used publicly",
+  "keywords": [
+    "bliss",
+    "react",
+    "component",
+    "utility"
+  ],
+  "homepage": "https://github.com/bliss-design/bliss",
+  "bugs": {
+    "url": "https://github.com/bliss-design/bliss/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bliss-design/bliss.git",
+    "directory": "packages/with-as-polymorphic"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Joe Takara",
+    "email": "anuchit.boonsom@gmail.com"
+  },
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src --dts",
+    "build:fast": "tsup src",
+    "clean": "rimraf dist .turbo",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.3.1",
+    "@types/react-dom": "^18.2.6",
+    "react": "^18.0.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0.22",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/with-as-polymorphic/src/index.ts
+++ b/packages/with-as-polymorphic/src/index.ts
@@ -1,0 +1,5 @@
+import withAsPolymorphic from './with-as-polymorphic';
+
+export type { ComponentPropsWithAs } from './with-as-polymorphic.types';
+
+export default withAsPolymorphic;

--- a/packages/with-as-polymorphic/src/with-as-polymorphic.tsx
+++ b/packages/with-as-polymorphic/src/with-as-polymorphic.tsx
@@ -1,0 +1,24 @@
+import type { ComponentPropsWithAs } from './with-as-polymorphic.types';
+
+import React from 'react';
+
+export default function withAsPolymorphic<
+  DefaultElement,
+  Props,
+  StaticProps = Record<string, never>,
+>(Component: React.ElementType) {
+  type ComponentWithProps<Element> = ComponentPropsWithAs<Element, Props>;
+
+  type ComponentType = <Element = DefaultElement>(
+    props: ComponentWithProps<Element>,
+  ) => React.ReactElement;
+
+  type FunctionComponent = Omit<
+    React.FunctionComponent<ComponentWithProps<unknown>>,
+    never
+  >;
+
+  type PolymorphicComponent = ComponentType & FunctionComponent & StaticProps;
+
+  return Component as PolymorphicComponent;
+}

--- a/packages/with-as-polymorphic/src/with-as-polymorphic.types.ts
+++ b/packages/with-as-polymorphic/src/with-as-polymorphic.types.ts
@@ -1,0 +1,38 @@
+import React from 'react';
+
+type MergeProps<ExistingProps = unknown, NewProps = unknown> = NewProps &
+  Omit<ExistingProps, keyof NewProps>;
+
+type JSXElement =
+  | keyof React.JSX.IntrinsicElements
+  | React.JSXElementConstructor<unknown>;
+
+type ManagedAttributes<Element extends JSXElement> =
+  React.JSX.LibraryManagedAttributes<
+    Element,
+    React.ComponentPropsWithoutRef<Element>
+  >;
+
+type ElementProp<Element> = {
+  as?: Element;
+};
+
+type MergedProps<
+  Element extends JSXElement,
+  AdditionalProps = unknown,
+> = MergeProps<ManagedAttributes<Element>, AdditionalProps>;
+
+type ElementRef<Element> = Element extends React.ElementType
+  ? React.ComponentPropsWithRef<Element>['ref']
+  : never;
+
+export type ComponentPropsWithAs<
+  Element,
+  AdditionalProps = Record<string, never>,
+> = Element extends React.ElementType
+  ? MergedProps<Element, AdditionalProps & ElementProp<Element>> & {
+      ref?: ElementRef<Element>;
+    }
+  : AdditionalProps & {
+      as: React.ElementType;
+    };

--- a/packages/with-as-polymorphic/tsconfig.json
+++ b/packages/with-as-polymorphic/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "jsx": "react",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "index.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/with-as-polymorphic/tsup.config.ts
+++ b/packages/with-as-polymorphic/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  clean: true,
+  target: ['es6'],
+  format: ['cjs', 'esm'],
+});


### PR DESCRIPTION
## Description

This PR accomplishes #2024: "Implement withAsPolymorphic Higher-Order Component". We've introduced a new utility, `withAsPolymorphic`, that enhances our components by adding polymorphic behavior based on the `as` prop.

## Types of Changes

- Feature

## Checklist:

- [x] I have read the [contributing](../CONTRIBUTING.md) document.
- [x] My changes are in a separate branch to the target branch.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.

## Impact / Severity

The impact of this PR is Medium. This will significantly improve our component API's flexibility and the developer experience, although it does not directly affect end users.

## Additional Info

The implemented `withAsPolymorphic` utility allows us to modify the `as` prop of our React components. It resides in its own package under the `packages/with-as-polymorphic` directory, ensuring isolated development and build process.

## Relevant Documentation or Resources

- React documentation: https://reactjs.org/docs/components-and-props.html#rendering-a-component
- TypeScript utility types documentation: https://www.typescriptlang.org/docs/handbook/utility-types.html
- TSUP documentation: https://tsup.egoist.sh/