### PR TITLE
fix(withPolymorphic): Missing types export

### DIFF
--- a/packages/with-polymorphic/src/index.ts
+++ b/packages/with-polymorphic/src/index.ts
@@ -1,5 +1,5 @@
 import withPolymorphic from './with-polymorphic';
 
-export type { ComponentProps } from './with-polymorphic.types';
+export type { ComponentPropsWithoutAs } from './with-polymorphic.types';
 
 export default withPolymorphic;


### PR DESCRIPTION
## Description

This PR Resolved #26: Fix missing export in "with-polymorphic.types"

## Types of Changes

- Bugfix

## Checklist:

- [x] I have read the [contributing](../CONTRIBUTING.md) document.
- [x] My changes are in a separate branch to the target branch.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.

## Impact / Severity

Medium - This fix addresses a bug that was causing issues with the import of the 'ComponentProps' export, impacting the functionality of the code.

## Additional Info

The missing export in the "with-polymorphic.types" module has been added, resolving the error when attempting to import the 'ComponentProps'.

## Relevant Documentation or Resources

No Relevant Documentation or Resources